### PR TITLE
fix make_cover_from_url when there is no cover

### DIFF
--- a/src/chapter_sync/cover.py
+++ b/src/chapter_sync/cover.py
@@ -70,7 +70,7 @@ def make_cover_from_url(url, title, author):
             cover = _convert_to_png(cover)
     except Exception as e:
         logger.info("Encountered an error downloading cover: " + str(e))
-        cover = make_cover_image(title, author)
+        return make_cover_image(title, author)
 
     return cover.read()
 


### PR DESCRIPTION
make_cover_image already calls `BytesIO.read()`

Fixes this error:

```
chapter-sync -v sync
Downloading cover from /dist/img/nocover-new-min.png
Encountered an error downloading cover: Invalid URL '/dist/img/nocover-new-min.png': No scheme supplied. Perhaps you
meant https:///dist/img/nocover-new-min.png?
Traceback (most recent call last):
  File "/opt/venv/bin/chapter-sync", line 6, in <module>
    sys.exit(run())
             ^^^^^
  File "/chapter-sync/src/chapter_sync/cli/base.py", line 178, in run
    cappa.invoke(ChapterSync, deps=[load_dotenv])
  File "/opt/venv/lib/python3.11/site-packages/cappa/base.py", line 141, in invoke
    with resolved.get(concrete_output) as value:
  File "/usr/local/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/cappa/invoke.py", line 65, in get
    result = callable(**finalized_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/chapter-sync/src/chapter_sync/sync.py", line 63, in sync
    save_series_ebooks(database, s, status)
  File "/chapter-sync/src/chapter_sync/sync.py", line 91, in save_series_ebooks
    ebook = Epub.from_series(series, chapter).write_buffer()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/chapter-sync/src/chapter_sync/epub.py", line 148, in from_series
    contents=cover.generate_image(series),
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/chapter-sync/src/chapter_sync/cover.py", line 49, in generate_image
    return make_cover_from_url(series.cover_url, series.title, series.author)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/chapter-sync/src/chapter_sync/cover.py", line 78, in make_cover_from_url
    return cover.read()
           ^^^^^^^^^^
AttributeError: 'bytes' object has no attribute 'read'
```